### PR TITLE
Features/14 register validation

### DIFF
--- a/src/features/forms/RegisterForm.jsx
+++ b/src/features/forms/RegisterForm.jsx
@@ -12,7 +12,7 @@ function RegisterForm() {
   //react-query
   const { register } = useRegister();
   const { emailConfirm, checkEmailConfirm } = useEmailConfirm();
-  console.log(checkEmailConfirm, "confirm");
+  // console.log(checkEmailConfirm, "confirm");
   //회원가입시 register에 보낼 정보
   const [registerInfo, setRegisterInfo] = useState({
     email: "",

--- a/src/features/forms/RegisterForm.jsx
+++ b/src/features/forms/RegisterForm.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import { registerInputList } from "./inputlist";
-import { useFormInput } from "../../hooks/useFormInput";
-import { Input } from "../../components/Input";
-import { RegisterBtn } from "../../components/Buttons";
+// import { registerInputList } from "./inputlist";
+// import { useFormInput } from "../../hooks/useFormInput";
+// import { Input } from "../../components/Input";
+// import { RegisterBtn } from "../../components/Buttons";
 import { Flex } from "../../components/Flex";
 import { Link } from "react-router-dom";
 import { useRegister } from "../../hooks/register,login/useRegister";
@@ -11,8 +11,8 @@ import { useEmailConfirm } from "../../hooks/register,login/useEmailConfirm";
 function RegisterForm() {
   //react-query
   const { register } = useRegister();
-  const { emailConfirm, error } = useEmailConfirm();
-
+  const { emailConfirm, checkEmailConfirm } = useEmailConfirm();
+  console.log(checkEmailConfirm, "confirm");
   //회원가입시 register에 보낼 정보
   const [registerInfo, setRegisterInfo] = useState({
     email: "",
@@ -42,7 +42,10 @@ function RegisterForm() {
     } else if (registerInfo.nickname.length < 2) {
       e.preventDefault();
       alert("닉네임을 2글자 이상 입력해주세요.");
-    } else {
+    } else if (checkEmailConfirm === false) {
+      e.preventDefault();
+      alert("이메일 중복확인을 진행해주세요.");
+    } else if (checkEmailConfirm === true) {
       e.preventDefault();
       register(registerInfo);
     }

--- a/src/features/forms/RegisterForm.jsx
+++ b/src/features/forms/RegisterForm.jsx
@@ -1,8 +1,4 @@
 import React, { useState } from "react";
-// import { registerInputList } from "./inputlist";
-// import { useFormInput } from "../../hooks/useFormInput";
-// import { Input } from "../../components/Input";
-// import { RegisterBtn } from "../../components/Buttons";
 import { Flex } from "../../components/Flex";
 import { Link } from "react-router-dom";
 import { useRegister } from "../../hooks/register,login/useRegister";
@@ -12,7 +8,7 @@ function RegisterForm() {
   //react-query
   const { register } = useRegister();
   const { emailConfirm, checkEmailConfirm } = useEmailConfirm();
-  // console.log(checkEmailConfirm, "confirm");
+
   //회원가입시 register에 보낼 정보
   const [registerInfo, setRegisterInfo] = useState({
     email: "",
@@ -42,6 +38,7 @@ function RegisterForm() {
     } else if (registerInfo.nickname.length < 2) {
       e.preventDefault();
       alert("닉네임을 2글자 이상 입력해주세요.");
+      //이메일 중복체크 확인 후 register에 payload 보내기
     } else if (checkEmailConfirm === false) {
       e.preventDefault();
       alert("이메일 중복확인을 진행해주세요.");
@@ -130,31 +127,3 @@ function RegisterForm() {
 }
 
 export default RegisterForm;
-
-//기존 작업물-------------------------------------------------------------
-// const [formState, setFormState, handleInputChange] = useFormInput();
-// const handleSubmit = event => {
-//   event.preventDefault();
-//   register(formState);
-//   setFormState({});
-// };
-
-// return (
-//   <Flex as="form" onSubmit={handleSubmit} fd="column" gap="10">
-//     <Link to="/">로고 자리(메인으로 돌아감)</Link>
-//     {registerInputList.map((input, index) => (
-//       <Input
-//         key={index}
-//         label={input.label}
-//         inputProps={{
-//           type: input.type,
-//           name: input.name,
-//           value: formState[input.name] || "",
-//           onChange: handleInputChange,
-//         }}
-//       />
-//     ))}
-//     <RegisterBtn type="submit">회원가입</RegisterBtn>
-//   </Flex>
-// );
-//기존 작업물-------------------------------------------------------------

--- a/src/features/forms/RegisterForm.jsx
+++ b/src/features/forms/RegisterForm.jsx
@@ -29,14 +29,42 @@ function RegisterForm() {
 
   //회원가입 버튼 클릭시 useRegister에 payload(registerInfo) 전달
   const registerHandler = e => {
-    e.preventDefault();
-    register(registerInfo);
+    //빈 값이 아닐때 register에 payload 보내기
+    if (registerInfo.email === "") {
+      alert("이메일을 입력해주세요.");
+      e.preventDefault();
+    } else if (registerInfo.password === "") {
+      alert("비밀번호를 입력해주세요.");
+      e.preventDefault();
+    } else if (registerInfo.nickname === "") {
+      alert("닉네임을 입력해주세요.");
+      e.preventDefault();
+    } else if (registerInfo.nickname.length < 2) {
+      e.preventDefault();
+      alert("닉네임을 2글자 이상 입력해주세요.");
+    } else {
+      e.preventDefault();
+      register(registerInfo);
+    }
   };
 
   //이메일 중복검사
+  const checkEmail = {
+    email: registerInfo.email,
+  };
+
   const emailConfirmHandler = e => {
-    e.preventDefault();
-    emailConfirm(registerInfo.email);
+    //빈값이 아닐때 보낼 수 있게 하기
+    if (registerInfo.email === "") {
+      alert("이메일을 입력해주세요.");
+      e.preventDefault();
+    } else if (!emailRegExp.test(registerInfo.email)) {
+      e.preventDefault();
+      return <div>이메일 형식이 올바르지 않습니다.</div>;
+    } else {
+      e.preventDefault();
+      emailConfirm(checkEmail);
+    }
   };
 
   //이메일, 비밀번호 형식 정규식 -> 확인해볼것

--- a/src/features/forms/RegisterForm.jsx
+++ b/src/features/forms/RegisterForm.jsx
@@ -6,11 +6,12 @@ import { RegisterBtn } from "../../components/Buttons";
 import { Flex } from "../../components/Flex";
 import { Link } from "react-router-dom";
 import { useRegister } from "../../hooks/register,login/useRegister";
+import { useEmailConfirm } from "../../hooks/register,login/useEmailConfirm";
 
 function RegisterForm() {
   //react-query
-  const { register, registerIsError } = useRegister();
-  console.log(registerIsError);
+  const { register } = useRegister();
+  const { emailConfirm, error } = useEmailConfirm();
 
   //회원가입시 register에 보낼 정보
   const [registerInfo, setRegisterInfo] = useState({
@@ -29,8 +30,13 @@ function RegisterForm() {
   //회원가입 버튼 클릭시 useRegister에 payload(registerInfo) 전달
   const registerHandler = e => {
     e.preventDefault();
-    console.log(registerInfo, "info");
     register(registerInfo);
+  };
+
+  //이메일 중복검사
+  const emailConfirmHandler = e => {
+    e.preventDefault();
+    emailConfirm(registerInfo.email);
   };
 
   //이메일, 비밀번호 형식 정규식 -> 확인해볼것
@@ -54,7 +60,6 @@ function RegisterForm() {
     if (registerInfo.password === "") {
       return "";
     } else if (!pwRegExp.test(registerInfo.password)) {
-      // alert("비밀번호 형식을 알맞게 맞춰주세요.");
       return "알파벳, 숫자, 특수문자 조합 6~15글자로 입력해주세요.";
     } else {
       return "";
@@ -77,6 +82,7 @@ function RegisterForm() {
       <Link to="/">로고 자리(메인으로 돌아감)</Link>
       <label>이메일</label>
       <input type="email" name="email" onChange={changeInputHandler} />
+      <button onClick={emailConfirmHandler}>중복확인</button>
       <div>{emailValidation()}</div>
 
       <label>비밀번호</label>

--- a/src/hooks/register,login/useEmailConfirm.js
+++ b/src/hooks/register,login/useEmailConfirm.js
@@ -7,10 +7,15 @@ export function useEmailConfirm() {
       const data = await apis.post("/user/emailconfirm", payload);
       return data;
     },
+    onSuccess: data => {
+      alert("사용 가능한 이메일입니다.");
+    },
+    onError: error => {
+      alert(error.response.data.errorMessage);
+    },
   });
 
   return {
     emailConfirm: mutate,
-    error,
   };
 }

--- a/src/hooks/register,login/useEmailConfirm.js
+++ b/src/hooks/register,login/useEmailConfirm.js
@@ -1,21 +1,31 @@
 import { useMutation } from "@tanstack/react-query";
 import { apis } from "../../api/apis";
+import { useState } from "react";
 
 export function useEmailConfirm() {
-  const { mutate, error } = useMutation({
+  const [checkEmailConfirm, setCheckEmailConfirm] = useState(false);
+
+  const { mutate } = useMutation({
     mutationFn: async payload => {
       const data = await apis.post("/user/emailconfirm", payload);
       return data;
     },
     onSuccess: data => {
-      alert("사용 가능한 이메일입니다.");
+      if (data.status === 201) {
+        alert("사용 가능한 이메일입니다");
+        setCheckEmailConfirm(true);
+      }
     },
     onError: error => {
-      alert(error.response.data.errorMessage);
+      if (error) {
+        setCheckEmailConfirm(false);
+        alert(error.response.data.errorMessage);
+      }
     },
   });
 
   return {
     emailConfirm: mutate,
+    checkEmailConfirm,
   };
 }

--- a/src/hooks/register,login/useEmailConfirm.js
+++ b/src/hooks/register,login/useEmailConfirm.js
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+import { apis } from "../../api/apis";
+
+export function useEmailConfirm() {
+  const { mutate, error } = useMutation({
+    mutationFn: async payload => {
+      const data = await apis.post("/user/emailconfirm", payload);
+      return data;
+    },
+  });
+
+  return {
+    emailConfirm: mutate,
+    error,
+  };
+}

--- a/src/hooks/register,login/useRegister.js
+++ b/src/hooks/register,login/useRegister.js
@@ -13,6 +13,9 @@ export function useRegister() {
       alert("회원 가입이 완료되었습니다!");
       navigate("/");
     },
+    onError: error => {
+      alert(error.response.data.errorMessage);
+    },
   });
   //밖에서 register라는 이름으로 해당 mutate 사용
   return {


### PR DESCRIPTION
회원가입 유효성검사
-> 공용 input, button 컴포넌트 사용 X

1. 회원가입 페이지 첫 마운트시 경고메시지 없음
2. 이메일 입력시 정규식 검사 -> 안 맞으면 "이메일 형식이 올바르지 않습니다." 띄움 / 맞으면 사라짐
3. 비밀번호 입력시 정규식 검사 -> 안 맞으면 "알파벳, 숫자, 특수문자 조합 6~15글자로 입력해주세요." 띄움 / 맞으면 사라짐
4. 닉네임 입력시 최소글자수(2글자) 체크 -> 안 맞으면 "2글자 이상 입력해주세요." 띄움 / 2글자 이상 입력시 사라짐
5. 이메일 중복검사 -> 기존에 있던 이메일이면 중복된 이메일이라는 alert 띄움
6. 이메일, 비밀번호, 닉네임 미입력한채로 회원가입 버튼 클릭시 입력하라는 alert 띄움
7. 이메일 중복검사 안 한채로 회원가입 버튼 클릭시 이메일 중복검사 하라는 alert 띄움

추후 리팩토링하여 유효성검사 전용 js파일 따로 뺄 예정입니다.