### PR TITLE
[fix] apis.js 파일에서 토큰 유무에 다른 변수 내용 변경함 #8

### DIFF
--- a/src/api/apis.js
+++ b/src/api/apis.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { cookies } from "../shared/cookies";
 
+const token = cookies.get("access_token");
+
 // 토큰없이 보낼때
 export const apis = axios.create({
   baseURL: process.env.REACT_APP_SERVER_URL,
@@ -9,13 +11,14 @@ export const apis = axios.create({
 // 토큰 넣어서 보낼때
 export const apis_token = axios.create({
   baseURL: process.env.REACT_APP_SERVER_URL,
+  headers: {
+    Authorization: `Bearer ${token}`,
+  },
 });
 
 apis_token.interceptors.request.use(
   // 요청을 보내기 전 수행되는 함수
   function (config) {
-    //TODOaccess_token이라고 사용. 나중에 수정 해야함
-    const token = cookies.get("access_token");
     //서버에서 token값만 받기로 함 -> Bearer 추가하여 header에 보낼 것.
     config.headers.Authorization = `Bearer ${token}`;
     return config;

--- a/src/hooks/mypage/useUpdateUserProfile.js
+++ b/src/hooks/mypage/useUpdateUserProfile.js
@@ -1,20 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { apis } from "../../api/apis";
+import { apis_token } from "../../api/apis";
 import { keys } from "../../shared/queryKeys";
-import { cookies } from "../../shared/cookies";
 
 export const useUpdateUserProfile = () => {
-  const token = cookies.get("access_token");
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
     mutationFn: async editProfile => {
       // console.log(editProfile, "editProfile");
-      const data = await apis.patch("/mypage", editProfile, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const data = await apis_token.patch("/mypage", editProfile);
       return data.data;
     },
     onSuccess: () => {


### PR DESCRIPTION
apis.js
토큰 없이 보낼 땐 baseURL만,
토큰 넣어서 보낼 땐 headers에 Authorization: `Bearer ${token}` 추가.

토큰 넣어서 보내는 apis_token 변수에 Authorization: `Bearer ${token}`이 없던 것 fix했습니다.