### PR TITLE
[fixed] 아트그램 상세모달 변경에 따른, 메인페이지에 연결된 컴포넌트참조 오류 #113

### DIFF
--- a/src/features/mypage/AlarmContainer.jsx
+++ b/src/features/mypage/AlarmContainer.jsx
@@ -5,7 +5,7 @@ import { useGetAlramInfo } from "../../hooks/mypage/useGetAlramInfo";
 import likeIcon from "../../assets/imgs/common/heart_red.png";
 import commentIcon from "../../assets/imgs/mypage/chat_blue.png";
 import { usePatchAlramInfo } from "../../hooks/mypage/usePatchAlramInfo";
-import ArtgarmDetailModal from "./../artgram/newartgram/ArtgarmDetailModal";
+import ArtgarmDetailModal from "./../artgram/detailModal/ArtgarmDetailModal";
 import { useOpenModal } from "./../../hooks/artgram/useOpenModal";
 import { useNavigate } from "react-router-dom";
 

--- a/src/features/mypage/ArtgramContainer.jsx
+++ b/src/features/mypage/ArtgramContainer.jsx
@@ -6,7 +6,7 @@ import { useGetScrapArtgramInfo } from "../../hooks/mypage/useGetScrapArtgramInf
 import { useOpenModal } from "./../../hooks/artgram/useOpenModal";
 import leftBtn from "../../assets/imgs/common/next_cut_gray2.png";
 import rightBtn from "../../assets/imgs/common/next_cut_gray2.png";
-import ArtgarmDetailModal from "../artgram/newartgram/ArtgarmDetailModal";
+import ArtgarmDetailModal from "../artgram/detailModal/ArtgarmDetailModal";
 
 function ArtgramContainer() {
   const { modalState, openModalhandle } = useOpenModal(); //아트그램 모달


### PR DESCRIPTION
메인페이지에 적용된 아트그램상세모달 컴포넌트의 수정 및 변경으로 인한 참조 에러 발생
경로 수정으로 문제 해결